### PR TITLE
Bugfix pybraries

### DIFF
--- a/libreselery/librariesio_connector.py
+++ b/libreselery/librariesio_connector.py
@@ -10,7 +10,9 @@ class Project(object):
         self.__dict__.update(d)
         # special vars
         self.platform = platform
-        self.owner = self.repository_url.split("/")[-2]
+        self.owner = ""
+        if self.repository_url:
+            self.owner = self.repository_url.split("/")[-2]
 
     def __repr__(self):
         return "%s: '%s' [%s]" % (self.name, self.repository_url, self.owner)
@@ -51,7 +53,7 @@ class LibrariesIOConnector(selery_utils.Connector):
         project = None
         search = Search()
         results = search.project_search(
-            filters={"keywords": depName, "manager": platform}
+            keywords=depName, sort="relevance", platform=platform
         )
         # only choose first search result
         if results:

--- a/libreselery/libreselery.py
+++ b/libreselery/libreselery.py
@@ -83,7 +83,7 @@ class LibreSelery(object):
         fundingPath = self._getFile("README.md")
         if fundingPath is not None:
             self.log("Loading funding file [%s] for bitcoin wallet" % fundingPath)
-            mdfile = open("README.md", "r")
+            mdfile = open(os.path.join(self.seleryDir, "README.md"), "r")
             mdstring = mdfile.read()
             urls = extractor.find_urls(mdstring)
             badge_string = "https://badgen.net/badge/LibreSelery-Donation/"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "pyyaml==5.3.1",
         "coinbase",
         "gitpython==3.1.7",
-        "pybraries==0.2.2",
+        "pybraries==0.3.0",
         "urlextract==1.0.0",
         "matplotlib==3.3.0",
         "numpy==1.19.1",


### PR DESCRIPTION
### General
this should solve the issue regarding dependency lookups with pybraries (see #98 )

### What changed
-  we are now using pybraries 0.3.0, reinstall libreselery via `python setup.py develop` to test that

### What was fixed as well

 - i also fixed a bug, where the readme.md file would have been parsed without providing a directory first, which fails whenever you are not in the same path as the readme itself.